### PR TITLE
docs : calendar api 문서 작성

### DIFF
--- a/api/src/main/java/com/lovely4k/backend/calendar/controller/CalendarController.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/controller/CalendarController.java
@@ -1,0 +1,80 @@
+package com.lovely4k.backend.calendar.controller;
+
+import com.lovely4k.backend.calendar.controller.request.CreateCalendarRequest;
+import com.lovely4k.backend.calendar.controller.request.FindAllCalendarsWithDateRequest;
+import com.lovely4k.backend.calendar.controller.request.UpdateCalendarRequest;
+import com.lovely4k.backend.calendar.service.CalendarCommandService;
+import com.lovely4k.backend.calendar.service.CalendarQueryService;
+import com.lovely4k.backend.calendar.service.response.CreateCalendarResponse;
+import com.lovely4k.backend.calendar.service.response.FindAllCalendarsWithDateServiceResponse;
+import com.lovely4k.backend.calendar.service.response.FindRecentCalendarsServiceResponse;
+import com.lovely4k.backend.calendar.service.response.UpdateCalendarResponse;
+import com.lovely4k.backend.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.hateoas.server.core.DummyInvocationUtils.methodOn;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+
+@RequestMapping(value = "/v1/calendars", produces = MediaTypes.HAL_JSON_VALUE)
+@RequiredArgsConstructor
+@RestController
+public class CalendarController {
+
+    private final CalendarCommandService calendarCommandService;
+    private final CalendarQueryService calendarQueryService;
+
+    private static final String CREATE_SCHEDULE = "createSchedule";
+    private static final String FIND_ALL_SCHEDULE_WITH_DATE = "findAllSchedulesWithDate";
+    private static final String EDIT_SCHEDULE_BY_ID = "editScheduleById";
+    private static final String DELETE_SCHEDULE_BY_ID = "deleteScheduleById";
+
+    @SneakyThrows
+    @GetMapping
+    public ResponseEntity<ApiResponse<FindAllCalendarsWithDateServiceResponse>> findAllSchedulesWithDate(@ModelAttribute FindAllCalendarsWithDateRequest request) {
+        return ApiResponse.ok(calendarQueryService.findAllCalendarsWithDate(request.toServiceDto()),
+                linkTo(methodOn(getClass()).findAllSchedulesWithDate(request)).withSelfRel(),
+                linkTo(getClass().getMethod(CREATE_SCHEDULE, Long.class, CreateCalendarRequest.class)).withRel(CREATE_SCHEDULE),
+                linkTo(getClass().getMethod(EDIT_SCHEDULE_BY_ID, Long.class, UpdateCalendarRequest.class)).withRel(EDIT_SCHEDULE_BY_ID),
+                linkTo(getClass().getMethod(DELETE_SCHEDULE_BY_ID, Long.class)).withRel(DELETE_SCHEDULE_BY_ID));
+    }
+
+    @SneakyThrows
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResponse<FindRecentCalendarsServiceResponse>> findRecentSchedules(@RequestParam("coupleId") Long coupleId, @RequestParam(value = "limit", defaultValue = "5") Long limit) {
+        return ApiResponse.ok(calendarQueryService.findRecentCalendars(coupleId, limit),
+                linkTo(methodOn(getClass()).findRecentSchedules(coupleId, limit)).withSelfRel(),
+                linkTo(getClass().getMethod(EDIT_SCHEDULE_BY_ID, Long.class, UpdateCalendarRequest.class)).withRel(EDIT_SCHEDULE_BY_ID));
+    }
+
+    @SneakyThrows
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<CreateCalendarResponse>> createSchedule(@RequestParam("coupleId") Long coupleId, @RequestBody CreateCalendarRequest request) {
+        CreateCalendarResponse response = calendarCommandService.createCalendar(coupleId, request.toServiceDto());
+
+        return ApiResponse.created(response, response.id(),
+                linkTo(methodOn(getClass()).createSchedule(coupleId, request)).withSelfRel(),
+                linkTo(getClass().getMethod(FIND_ALL_SCHEDULE_WITH_DATE, FindAllCalendarsWithDateRequest.class)).withRel(FIND_ALL_SCHEDULE_WITH_DATE));
+    }
+
+    @SneakyThrows
+    @PatchMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<UpdateCalendarResponse>> editScheduleById(@PathVariable("id") Long id, @RequestBody UpdateCalendarRequest request) {
+        UpdateCalendarResponse response = calendarCommandService.updateCalendarById(id, request.toServiceDto());
+        return ApiResponse.ok(response,
+                linkTo(methodOn(getClass()).editScheduleById(id, request)).withSelfRel(),
+                linkTo(getClass().getMethod(FIND_ALL_SCHEDULE_WITH_DATE, FindAllCalendarsWithDateRequest.class)).withRel(FIND_ALL_SCHEDULE_WITH_DATE));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteScheduleById(@PathVariable("id") Long id) {
+        calendarCommandService.deleteCalendarById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/controller/request/CreateCalendarRequest.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/controller/request/CreateCalendarRequest.java
@@ -1,0 +1,23 @@
+package com.lovely4k.backend.calendar.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+import com.lovely4k.backend.calendar.service.request.CreateCalendarServiceReqeust;
+
+import java.time.LocalDate;
+
+public record CreateCalendarRequest(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+    public CreateCalendarServiceReqeust toServiceDto() {
+        return new CreateCalendarServiceReqeust(startDate, endDate, scheduleDetails, scheduleType);
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/controller/request/FindAllCalendarsWithDateRequest.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/controller/request/FindAllCalendarsWithDateRequest.java
@@ -1,0 +1,21 @@
+package com.lovely4k.backend.calendar.controller.request;
+
+import com.lovely4k.backend.calendar.service.response.FindAllCalendarsWithDateServiceRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record FindAllCalendarsWithDateRequest(
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        long coupleId
+) {
+    public FindAllCalendarsWithDateServiceRequest toServiceDto() {
+        return new FindAllCalendarsWithDateServiceRequest(startDate, endDate, coupleId);
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/controller/request/UpdateCalendarRequest.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/controller/request/UpdateCalendarRequest.java
@@ -1,0 +1,23 @@
+package com.lovely4k.backend.calendar.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+import com.lovely4k.backend.calendar.service.request.UpdateCalendarServiceRequest;
+
+import java.time.LocalDate;
+
+public record UpdateCalendarRequest(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+    public UpdateCalendarServiceRequest toServiceDto() {
+        return new UpdateCalendarServiceRequest(startDate, endDate, scheduleDetails, scheduleType);
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarCommandService.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarCommandService.java
@@ -1,0 +1,30 @@
+package com.lovely4k.backend.calendar.service;
+
+import com.lovely4k.backend.calendar.repository.CalendarCommandRepository;
+import com.lovely4k.backend.calendar.service.request.CreateCalendarServiceReqeust;
+import com.lovely4k.backend.calendar.service.request.UpdateCalendarServiceRequest;
+import com.lovely4k.backend.calendar.service.response.CreateCalendarResponse;
+import com.lovely4k.backend.calendar.service.response.UpdateCalendarResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class CalendarCommandService {
+
+    private final CalendarCommandRepository calendarCommandRepository;
+
+    public CreateCalendarResponse createCalendar(Long coupleId, CreateCalendarServiceReqeust serviceDto) {
+        calendarCommandRepository.findById(coupleId);
+        return CreateCalendarResponse.from();
+    }
+
+    public UpdateCalendarResponse updateCalendarById(Long id, UpdateCalendarServiceRequest request) {
+        return UpdateCalendarResponse.from();
+    }
+
+    public void deleteCalendarById(Long id) {
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarQueryService.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarQueryService.java
@@ -1,0 +1,40 @@
+package com.lovely4k.backend.calendar.service;
+
+import com.lovely4k.backend.calendar.ScheduleType;
+import com.lovely4k.backend.calendar.repository.CalendarQueryRepository;
+import com.lovely4k.backend.calendar.repository.response.ColorResponse;
+import com.lovely4k.backend.calendar.service.response.FindAllCalendarsWithDateServiceRequest;
+import com.lovely4k.backend.calendar.service.response.FindAllCalendarsWithDateServiceResponse;
+import com.lovely4k.backend.calendar.service.response.FindRecentCalendarsServiceResponse;
+import com.lovely4k.backend.calendar.service.response.ScheduleServiceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CalendarQueryService {
+
+    private final CalendarQueryRepository calendarQueryRepository;
+
+    public FindAllCalendarsWithDateServiceResponse findAllCalendarsWithDate(FindAllCalendarsWithDateServiceRequest request) {
+        calendarQueryRepository.findAll();
+        return new FindAllCalendarsWithDateServiceResponse(
+                new ColorResponse(1L, "yellow"),
+                new ColorResponse(2L, "green"),
+                List.of(new ScheduleServiceResponse(LocalDate.now(), LocalDate.now(), "놀러가기", ScheduleType.DATE))
+        );
+    }
+
+    public FindRecentCalendarsServiceResponse findRecentCalendars(Long coupleId, Long limit) {
+        return new FindRecentCalendarsServiceResponse(
+                new ColorResponse(1L, "yellow"),
+                new ColorResponse(2L, "green"),
+                List.of(new ScheduleServiceResponse(LocalDate.now(), LocalDate.now(), "놀러가기", ScheduleType.DATE))
+        );
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/request/CreateCalendarServiceReqeust.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/request/CreateCalendarServiceReqeust.java
@@ -1,0 +1,19 @@
+package com.lovely4k.backend.calendar.service.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record CreateCalendarServiceReqeust(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/request/UpdateCalendarServiceRequest.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/request/UpdateCalendarServiceRequest.java
@@ -1,0 +1,18 @@
+package com.lovely4k.backend.calendar.service.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record UpdateCalendarServiceRequest(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/CreateCalendarResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/CreateCalendarResponse.java
@@ -1,0 +1,23 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record CreateCalendarResponse(
+        long id,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+    public static CreateCalendarResponse from() {
+        return new CreateCalendarResponse(1L, LocalDate.now(), LocalDate.now(), "details", ScheduleType.DATE);
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindAllCalendarsWithDateServiceRequest.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindAllCalendarsWithDateServiceRequest.java
@@ -1,0 +1,10 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import java.time.LocalDate;
+
+public record FindAllCalendarsWithDateServiceRequest(
+        LocalDate startDate,
+        LocalDate endDate,
+        long coupleId
+) {
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindAllCalendarsWithDateServiceResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindAllCalendarsWithDateServiceResponse.java
@@ -1,0 +1,31 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import com.lovely4k.backend.calendar.repository.response.ColorResponse;
+import com.lovely4k.backend.calendar.repository.response.FindAllCalendarsWithDateResponse;
+
+import java.util.List;
+
+public record FindAllCalendarsWithDateServiceResponse(
+        ColorResponse firstColor,
+        ColorResponse secondColor,
+        List<ScheduleServiceResponse> schedules
+) {
+    public static FindAllCalendarsWithDateServiceResponse from(FindAllCalendarsWithDateResponse response) {
+        List<ScheduleServiceResponse> scheduleServiceResponses = response
+                .schedules()
+                .stream()
+                .map(schedule -> new ScheduleServiceResponse(
+                        schedule.startDate(),
+                        schedule.endDate(),
+                        schedule.scheduleDetails(),
+                        schedule.scheduleType()
+                ))
+                .toList();
+
+        return new FindAllCalendarsWithDateServiceResponse(
+                response.firstColor(),
+                response.secondColor(),
+                scheduleServiceResponses
+        );
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindRecentCalendarsServiceResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/FindRecentCalendarsServiceResponse.java
@@ -1,0 +1,31 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import com.lovely4k.backend.calendar.repository.response.ColorResponse;
+import com.lovely4k.backend.calendar.repository.response.FindRecentCalendarsResponse;
+
+import java.util.List;
+
+public record FindRecentCalendarsServiceResponse(
+        ColorResponse firstColor,
+        ColorResponse secondColor,
+        List<ScheduleServiceResponse> schedules
+) {
+    public static FindRecentCalendarsServiceResponse from(FindRecentCalendarsResponse response) {
+        List<ScheduleServiceResponse> scheduleServiceResponses = response
+                .schedules()
+                .stream()
+                .map(schedule -> new ScheduleServiceResponse(
+                        schedule.startDate(),
+                        schedule.endDate(),
+                        schedule.scheduleDetails(),
+                        schedule.scheduleType()
+                ))
+                .toList();
+
+        return new FindRecentCalendarsServiceResponse(
+                response.firstColor(),
+                response.secondColor(),
+                scheduleServiceResponses
+        );
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/ScheduleServiceResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/ScheduleServiceResponse.java
@@ -1,0 +1,19 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record ScheduleServiceResponse(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+}

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/response/UpdateCalendarResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/response/UpdateCalendarResponse.java
@@ -1,0 +1,23 @@
+package com.lovely4k.backend.calendar.service.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record UpdateCalendarResponse(
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+
+    public static UpdateCalendarResponse from() {
+        return new UpdateCalendarResponse(LocalDate.now(), LocalDate.now(), "details", ScheduleType.DATE);
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/common/log/HttpAspect.java
+++ b/api/src/main/java/com/lovely4k/backend/common/log/HttpAspect.java
@@ -45,7 +45,7 @@ public class HttpAspect {
         double elapsedTime = (endTime - startTime) * MILLI_SECOND_TO_SECOND_UNIT;
 
         HttpServletResponse response = sra.getResponse();
-        HttpLog httpLog = HttpLog.of(request, Objects.requireNonNull(response), objectMapper, proceed);
+        HttpLogResponse httpLog = HttpLogResponse.of(request, Objects.requireNonNull(response), objectMapper, proceed);
 
         if (elapsedTime > maxAffordableTime) {
             log.warn(objectMapper.writeValueAsString(httpLog));
@@ -70,7 +70,7 @@ public class HttpAspect {
         Object proceed = joinPoint.proceed();
         HttpServletResponse response = sra.getResponse();
 
-        log.warn(objectMapper.writeValueAsString(HttpLog.of(request, Objects.requireNonNull(response), objectMapper, proceed)));
+        log.warn(objectMapper.writeValueAsString(HttpLogResponse.of(request, Objects.requireNonNull(response), objectMapper, proceed)));
 
         return proceed;
     }

--- a/api/src/main/java/com/lovely4k/backend/common/log/HttpLogResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/common/log/HttpLogResponse.java
@@ -7,7 +7,7 @@ import lombok.SneakyThrows;
 
 import java.util.Map;
 
-public record HttpLog(
+public record HttpLogResponse(
     String ipAddress,
     String header,
     String uri,
@@ -19,7 +19,7 @@ public record HttpLog(
 ) {
 
     @SneakyThrows
-    public static HttpLog of(HttpServletRequest request, HttpServletResponse response, ObjectMapper objectMapper, Object proceed) {
+    public static HttpLogResponse of(HttpServletRequest request, HttpServletResponse response, ObjectMapper objectMapper, Object proceed) {
         String header = request.getHeader("User-Agent");
 
         String uri = request.getRequestURI();
@@ -30,7 +30,7 @@ public record HttpLog(
         int status = response.getStatus();
         String responseBody = proceed != null ? proceed.toString() : null;
 
-        return new HttpLog(getIpAddress(request), header, uri, requestBody, responseBody, parameter, httpMethod, status);
+        return new HttpLogResponse(getIpAddress(request), header, uri, requestBody, responseBody, parameter, httpMethod, status);
     }
 
     private static String getIpAddress(HttpServletRequest request) {
@@ -41,8 +41,8 @@ public record HttpLog(
         return ipAddress;
     }
 
-    public HttpLog removeBody() {
-        return new HttpLog(ipAddress, header, uri, "", "", parameter, httpMethod, status);
+    public HttpLogResponse removeBody() {
+        return new HttpLogResponse(ipAddress, header, uri, "", "", parameter, httpMethod, status);
     }
 
 }

--- a/api/src/main/java/com/lovely4k/backend/question/controller/QuestionController.java
+++ b/api/src/main/java/com/lovely4k/backend/question/controller/QuestionController.java
@@ -41,9 +41,9 @@ public class QuestionController {
     public ResponseEntity<ApiResponse<DailyQuestionResponse>> getDailyQuestion(@RequestParam("coupleId") Long coupleId) {
 
         return ApiResponse.ok(questionService.findDailyQuestion(coupleId),
-                linkTo(methodOn(getClass()).getDailyQuestion(coupleId)).withSelfRel(),
-                linkTo(getClass().getMethod(CREATE_QUESTION, Long.class)).withRel(CREATE_QUESTION),
-                linkTo(getClass().getMethod(CREATE_QUESTION_FORM, CreateQuestionFormRequest.class, Long.class, Long.class)).withRel(CREATE_QUESTION_FORM));
+            linkTo(methodOn(getClass()).getDailyQuestion(coupleId)).withSelfRel(),
+            linkTo(getClass().getMethod(CREATE_QUESTION, Long.class)).withRel(CREATE_QUESTION),
+            linkTo(getClass().getMethod(CREATE_QUESTION_FORM, CreateQuestionFormRequest.class, Long.class, Long.class)).withRel(CREATE_QUESTION_FORM));
     }
 
     @SneakyThrows
@@ -52,9 +52,9 @@ public class QuestionController {
         CreateQuestionFormResponse response = questionService.createQuestionForm(request.toServiceDto(), coupleId, memberId);
 
         return ApiResponse.created(response, response.questionId(),
-                linkTo(methodOn(getClass()).createQuestionForm(request, memberId, coupleId)).withSelfRel(),
-                linkTo(getClass().getMethod(ANSWER_QUESTION, Long.class, Sex.class, AnswerQuestionRequest.class)).withRel(ANSWER_QUESTION),
-                linkTo(getClass().getMethod(GET_DAILY_QUESTION, Long.class)).withRel(GET_DAILY_QUESTION));
+            linkTo(methodOn(getClass()).createQuestionForm(request, memberId, coupleId)).withSelfRel(),
+            linkTo(getClass().getMethod(ANSWER_QUESTION, Long.class, Sex.class, AnswerQuestionRequest.class)).withRel(ANSWER_QUESTION),
+            linkTo(getClass().getMethod(GET_DAILY_QUESTION, Long.class)).withRel(GET_DAILY_QUESTION));
     }
 
 
@@ -64,8 +64,8 @@ public class QuestionController {
         CreateQuestionResponse response = questionService.createQuestion(coupleId);
 
         return ApiResponse.created(response, response.questionId(),
-                linkTo(methodOn(getClass()).createQuestion(coupleId)).withSelfRel(),
-                linkTo(getClass().getMethod(GET_DAILY_QUESTION, Long.class)).withRel(GET_DAILY_QUESTION));
+            linkTo(methodOn(getClass()).createQuestion(coupleId)).withSelfRel(),
+            linkTo(getClass().getMethod(GET_DAILY_QUESTION, Long.class)).withRel(GET_DAILY_QUESTION));
     }
 
 
@@ -75,17 +75,17 @@ public class QuestionController {
         questionService.updateQuestionAnswer(id, sex, request.choiceNumber());
 
         return ApiResponse.ok(
-                linkTo(methodOn(getClass()).answerQuestion(id, sex, request)).withSelfRel(),
-                linkTo(getClass().getMethod(GET_ANSWERED_QUESTIONS, AnsweredQuestionParamRequest.class)).withRel(GET_ANSWERED_QUESTIONS),
-                linkTo(getClass().getMethod(GET_QUESTION_DETAILS, Long.class, Long.class, Sex.class)).withRel(GET_QUESTION_DETAILS));
+            linkTo(methodOn(getClass()).answerQuestion(id, sex, request)).withSelfRel(),
+            linkTo(getClass().getMethod(GET_ANSWERED_QUESTIONS, AnsweredQuestionParamRequest.class)).withRel(GET_ANSWERED_QUESTIONS),
+            linkTo(getClass().getMethod(GET_QUESTION_DETAILS, Long.class, Long.class, Sex.class)).withRel(GET_QUESTION_DETAILS));
     }
 
     @SneakyThrows
     @GetMapping
     public ResponseEntity<ApiResponse<AnsweredQuestionResponse>> getAnsweredQuestions(@ModelAttribute @Valid AnsweredQuestionParamRequest params) {
         return ApiResponse.ok(questionService.findAllAnsweredQuestionByCoupleId(params.getId(), params.getCoupleId(), params.getLimit()),
-                linkTo(methodOn(getClass()).getAnsweredQuestions(params)).withSelfRel(),
-                linkTo(getClass().getMethod(GET_QUESTION_DETAILS, Long.class, Long.class, Sex.class)).withRel(GET_QUESTION_DETAILS));
+            linkTo(methodOn(getClass()).getAnsweredQuestions(params)).withSelfRel(),
+            linkTo(getClass().getMethod(GET_QUESTION_DETAILS, Long.class, Long.class, Sex.class)).withRel(GET_QUESTION_DETAILS));
     }
 
 
@@ -93,8 +93,8 @@ public class QuestionController {
     @GetMapping("/details/{id}")
     public ResponseEntity<ApiResponse<QuestionDetailsResponse>> getQuestionDetails(@PathVariable("id") Long id, @RequestParam("memberId") Long memberId, @RequestParam("sex") Sex sex) {
         return ApiResponse.ok(questionQueryService.findQuestionDetails(id, memberId, sex),
-                linkTo(methodOn(getClass()).getQuestionDetails(id, memberId, sex)).withSelfRel(),
-                linkTo(getClass().getMethod(GET_ANSWERED_QUESTIONS, AnsweredQuestionParamRequest.class)).withRel(GET_ANSWERED_QUESTIONS));
+            linkTo(methodOn(getClass()).getQuestionDetails(id, memberId, sex)).withSelfRel(),
+            linkTo(getClass().getMethod(GET_ANSWERED_QUESTIONS, AnsweredQuestionParamRequest.class)).withRel(GET_ANSWERED_QUESTIONS));
     }
 
     //관리자용 엔드포인트

--- a/api/src/main/resources/schema/schema.sql
+++ b/api/src/main/resources/schema/schema.sql
@@ -101,3 +101,17 @@ CREATE TABLE question_form (
     INDEX idx_question_form_member_id (member_id),
     INDEX idx_question_form_question_day (question_day)
 );
+
+CREATE TABLE calendar(
+     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     start_date DATE NOT NULL,
+     end_date DATE,
+     member_id BIGINT,
+     schedule_type VARCHAR(31) NOT NULL,
+     schedule_details VARCHAR(255) NOT NULL,
+     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+     INDEX idx_calendar_member_id (member_id),
+     INDEX idx_calendar_start_date (start_date),
+     INDEX idx_calendar_end_Date (end_date)
+);

--- a/api/src/test/java/com/lovely4k/backend/architect/ArchTests.java
+++ b/api/src/test/java/com/lovely4k/backend/architect/ArchTests.java
@@ -125,13 +125,13 @@ class ArchTests {
     @Test
     void serviceDependencyInjectionTest() {
         ArchRule serviceDependencyInjectRule = classes().that().haveSimpleNameEndingWith("Service")
-                .should(new ArchCondition<>("have 5 or fewer final fields for dependency injection") {
-                    @Override
-                    public void check(JavaClass item, ConditionEvents events) {
-                        long finalFieldCount = item.getFields().stream()
-                                .filter(field -> field.getModifiers().contains(JavaModifier.FINAL))
-                                .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))  // static 필드 제외
-                                .count();
+            .should(new ArchCondition<>("have 5 or fewer final fields for dependency injection") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                    long finalFieldCount = item.getFields().stream()
+                        .filter(field -> field.getModifiers().contains(JavaModifier.FINAL))
+                        .filter(field -> !field.getModifiers().contains(JavaModifier.STATIC))  // static 필드 제외
+                        .count();
 
                     boolean satisfied = finalFieldCount <= 5;
 
@@ -145,9 +145,9 @@ class ArchTests {
     }
 
     @DisplayName("""
-            Service class에는 @Transactional(readOnly=true) 옵션이 붙어 있어야 하며,"
-            find로 시작하지 않는 public 메서드는 @Transactional 옵션을 붙여 주어야 한다. 
-            """)
+        Service class에는 @Transactional(readOnly=true) 옵션이 붙어 있어야 하며,"
+        find로 시작하지 않는 public 메서드는 @Transactional 옵션을 붙여 주어야 한다. 
+        """)
     @Test
     void readOnlyTest() {
         ArchRule rule = classes()
@@ -166,9 +166,8 @@ class ArchTests {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 Optional<JavaAnnotation<JavaClass>> transactionalAnnotation = findTransactionalAnnotation(item);
-                boolean satisfied = true;
-                if (!transactionalAnnotation.isPresent()) satisfied = false;
-                Optional<Object> readOnlyValue = transactionalAnnotation.get().get("readOnly");
+                boolean satisfied = transactionalAnnotation.isPresent();
+                Optional<Object> readOnlyValue = transactionalAnnotation.flatMap(annotation -> annotation.get("readOnly"));
                 if (!isReadOnlyTrue(readOnlyValue)) satisfied = false;
 
                 events.add(new SimpleConditionEvent(item, satisfied, item.getName()));

--- a/api/src/test/java/com/lovely4k/docs/calendar/CalendarApiDocsTest.java
+++ b/api/src/test/java/com/lovely4k/docs/calendar/CalendarApiDocsTest.java
@@ -1,0 +1,230 @@
+package com.lovely4k.docs.calendar;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.lovely4k.backend.calendar.ScheduleType;
+import com.lovely4k.backend.calendar.controller.CalendarController;
+import com.lovely4k.backend.calendar.controller.request.CreateCalendarRequest;
+import com.lovely4k.backend.calendar.controller.request.UpdateCalendarRequest;
+import com.lovely4k.backend.calendar.repository.response.ColorResponse;
+import com.lovely4k.backend.calendar.service.CalendarCommandService;
+import com.lovely4k.backend.calendar.service.CalendarQueryService;
+import com.lovely4k.backend.calendar.service.request.CreateCalendarServiceReqeust;
+import com.lovely4k.backend.calendar.service.request.UpdateCalendarServiceRequest;
+import com.lovely4k.backend.calendar.service.response.*;
+import com.lovely4k.docs.RestDocsSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CalendarApiDocsTest extends RestDocsSupport {
+
+    private final CalendarCommandService calendarCommandService = mock(CalendarCommandService.class);
+    private final CalendarQueryService calendarQueryService = mock(CalendarQueryService.class);
+
+    @Override
+    protected Object initController() {
+        return new CalendarController(calendarCommandService, calendarQueryService);
+    }
+
+    @DisplayName("startDate ~ endDate 기간에 해당하는 일정 조회 api docs")
+    @Test
+    void findAllSchedulesWithDate() throws Exception {
+        // Given
+        FindAllCalendarsWithDateServiceResponse response = new FindAllCalendarsWithDateServiceResponse(
+                new ColorResponse(1L, "yellow"),
+                new ColorResponse(2L, "green"),
+                List.of(new ScheduleServiceResponse(LocalDate.now(), LocalDate.now(), "놀러가기", ScheduleType.DATE))
+        );
+
+        given(calendarQueryService.findAllCalendarsWithDate(any(FindAllCalendarsWithDateServiceRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/v1/calendars")
+                        .queryParam("startDate", "2023-01-01")
+                        .queryParam("endDate", "2023-01-31")
+                        .queryParam("coupleId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("find-all-schedules-with-date",
+                        queryParameters(
+                                parameterWithName("startDate").description("조회 시작 날짜"),
+                                parameterWithName("endDate").description("조회 종료 날짜"),
+                                parameterWithName("coupleId").description("커플 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+                                fieldWithPath("body.firstColor.memberId").type(JsonFieldType.NUMBER).description("첫 번째 색상의 회원 ID"),
+                                fieldWithPath("body.firstColor.calendarColor").type(JsonFieldType.STRING).description("첫 번째 색상"),
+                                fieldWithPath("body.secondColor.memberId").type(JsonFieldType.NUMBER).description("두 번째 색상의 회원 ID"),
+                                fieldWithPath("body.secondColor.calendarColor").type(JsonFieldType.STRING).description("두 번째 색상"),
+                                fieldWithPath("body.schedules[0].startDate").type(JsonFieldType.STRING).description("일정 시작 날짜"),
+                                fieldWithPath("body.schedules[0].endDate").type(JsonFieldType.STRING).description("일정 종료 날짜"),
+                                fieldWithPath("body.schedules[0].scheduleDetails").type(JsonFieldType.STRING).description("일정 상세"),
+                                fieldWithPath("body.schedules[0].scheduleType").type(JsonFieldType.STRING).description("일정 타입(공통 일정이 아닌 경우 PRIVATE로 반환)"),
+                                fieldWithPath("links[0].rel").type(STRING).description("URL과의 관계"),
+                                fieldWithPath("links[0].href").type(STRING).description("URL의 링크")
+                        )
+                ));
+    }
+
+    @DisplayName("최근 일정을 조회하는 api docs")
+    @Test
+    void findRecentSchedules() throws Exception {
+        // Given
+        FindRecentCalendarsServiceResponse response = new FindRecentCalendarsServiceResponse(
+                new ColorResponse(1L, "yellow"),
+                new ColorResponse(2L, "green"),
+                List.of(new ScheduleServiceResponse(LocalDate.now(), LocalDate.now(), "놀러가기", ScheduleType.DATE))
+        );
+
+        given(calendarQueryService.findRecentCalendars(anyLong(), anyLong()))
+                .willReturn(response);
+
+        mockMvc.perform(get("/v1/calendars/recent")
+                        .queryParam("coupleId", "1")
+                        .queryParam("limit", "5")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("find-recent-schedules",
+                        queryParameters(
+                                parameterWithName("coupleId").description("커플 ID"),
+                                parameterWithName("limit").description("조회할 개수 default 5")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+                                fieldWithPath("body.firstColor.memberId").type(JsonFieldType.NUMBER).description("첫 번째 색상의 회원 ID"),
+                                fieldWithPath("body.firstColor.calendarColor").type(JsonFieldType.STRING).description("첫 번째 색상"),
+                                fieldWithPath("body.secondColor.memberId").type(JsonFieldType.NUMBER).description("두 번째 색상의 회원 ID"),
+                                fieldWithPath("body.secondColor.calendarColor").type(JsonFieldType.STRING).description("두 번째 색상"),
+                                fieldWithPath("body.schedules[0].startDate").type(STRING).description("일정 시작 날짜"),
+                                fieldWithPath("body.schedules[0].endDate").type(JsonFieldType.STRING).description("일정 종료 날짜"),
+                                fieldWithPath("body.schedules[0].scheduleDetails").type(JsonFieldType.STRING).description("일정 상세"),
+                                fieldWithPath("body.schedules[0].scheduleType").type(JsonFieldType.STRING).description("일정 타입(공통 일정이 아닌 경우 PRIVATE로 반환)"),
+                                fieldWithPath("links[0].rel").type(STRING).description("URL과의 관계"),
+                                fieldWithPath("links[0].href").type(STRING).description("URL의 링크")
+                        )
+                ));
+    }
+
+    @DisplayName("일정을 생성하는 api docs")
+    @Test
+    void createSchedule() throws Exception {
+        // Given
+        CreateCalendarRequest request = new CreateCalendarRequest(LocalDate.now(), LocalDate.now(), "details", ScheduleType.DATE);
+
+        CreateCalendarResponse response = new CreateCalendarResponse(1L, LocalDate.now(), LocalDate.now(), "details", ScheduleType.DATE);
+
+        given(calendarCommandService.createCalendar(anyLong(), any(CreateCalendarServiceReqeust.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/v1/calendars")
+                        .queryParam("coupleId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(request))
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andDo(document("create-schedules",
+                        queryParameters(
+                                parameterWithName("coupleId").description("커플 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("startDate").type(JsonFieldType.STRING).description("일정 시작 날짜"),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("일정 종료 날짜"),
+                                fieldWithPath("scheduleDetails").type(JsonFieldType.STRING).description("일정에 대한 상세 설명"),
+                                fieldWithPath("scheduleType").type(JsonFieldType.STRING).description("일정의 유형 (DATE, TIME 등)")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("코드"),
+                                fieldWithPath("body.id").type(JsonFieldType.NUMBER).description("생성된 일정의 ID"),
+                                fieldWithPath("body.startDate").type(JsonFieldType.STRING).description("일정 시작 날짜"),
+                                fieldWithPath("body.endDate").type(STRING).description("일정 종료 날짜"),
+                                fieldWithPath("body.scheduleDetails").type(JsonFieldType.STRING).description("일정 상세 정보"),
+                                fieldWithPath("body.scheduleType").type(JsonFieldType.STRING).description("일정 유형"),
+                                fieldWithPath("links[0].rel").type(STRING).description("URL과의 관계"),
+                                fieldWithPath("links[0].href").type(STRING).description("URL의 링크")
+                        )
+                ));
+    }
+
+    @DisplayName("일정을 수정하는 api docs")
+    @Test
+    void editScheduleById() throws Exception {
+        // Given
+        Long scheduleId = 1L;
+        UpdateCalendarRequest updateRequest = new UpdateCalendarRequest(LocalDate.now(), LocalDate.now(), "updated details", ScheduleType.DATE);
+        UpdateCalendarResponse updateResponse = new UpdateCalendarResponse(LocalDate.now(), LocalDate.now(), "updated details", ScheduleType.DATE);
+
+        given(calendarCommandService.updateCalendarById(eq(scheduleId), any(UpdateCalendarServiceRequest.class)))
+                .willReturn(updateResponse);
+
+        // When & Then
+        mockMvc.perform(patch("/v1/calendars/{id}", scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(updateRequest))
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("edit-schedule",
+                        pathParameters(
+                                parameterWithName("id").description("일정 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("startDate").type(JsonFieldType.STRING).description("일정 시작 날짜"),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("일정 종료 날짜"),
+                                fieldWithPath("scheduleDetails").type(JsonFieldType.STRING).description("일정에 대한 상세 설명"),
+                                fieldWithPath("scheduleType").type(JsonFieldType.STRING).description("일정의 유형 (DATE, TIME 등)")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("body.startDate").type(JsonFieldType.STRING).description("수정된 일정 시작 날짜"),
+                                fieldWithPath("body.endDate").type(JsonFieldType.STRING).description("수정된 일정 종료 날짜"),
+                                fieldWithPath("body.scheduleDetails").type(JsonFieldType.STRING).description("수정된 일정 상세 정보"),
+                                fieldWithPath("body.scheduleType").type(JsonFieldType.STRING).description("수정된 일정 유형"),
+                                fieldWithPath("links[0].rel").type(STRING).description("URL과의 관계"),
+                                fieldWithPath("links[0].href").type(STRING).description("URL의 링크")
+                        )
+                ));
+    }
+
+    @DisplayName("일정을 삭제하는 API 테스트")
+    @Test
+    void deleteScheduleById() throws Exception {
+        // Given
+        Long scheduleId = 1L;
+
+        willDoNothing().given(calendarCommandService).deleteCalendarById(scheduleId);
+
+        // When & Then
+        mockMvc.perform(delete("/v1/calendars/{id}", scheduleId))
+                .andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("delete-schedule",
+                        pathParameters(
+                                parameterWithName("id").description("삭제할 일정의 ID")
+                        )
+                ));
+    }
+
+}

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -34,4 +34,3 @@ logging:
 love:
   system:
     max-affordable-time: 3
-    milli-seconds-to-second-unit: 0.001

--- a/model/src/main/java/com/lovely4k/backend/calendar/Calendar.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/Calendar.java
@@ -1,0 +1,50 @@
+package com.lovely4k.backend.calendar;
+
+import com.lovely4k.backend.common.jpa.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Calendar extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "member_id")
+    private long ownerId;
+
+    @Column(name = "schedule_type")
+    @Enumerated(EnumType.STRING)
+    private ScheduleType scheduleType;
+
+    @Column(name = "schedule_details")
+    private String scheduleDetails;
+
+    private Calendar(LocalDate startDate, LocalDate endDate, long ownerId, ScheduleType scheduleType, String scheduleDetails) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.ownerId = ownerId;
+        this.scheduleType = scheduleType;
+        this.scheduleDetails = scheduleDetails;
+    }
+
+    public static Calendar create(LocalDate startDate, LocalDate endDate, long ownerId, ScheduleType scheduleType, String scheduleDetails) {
+        if (scheduleType == ScheduleType.PERSONAL) {
+            ownerId = 0L;
+        }
+        return new Calendar(startDate, endDate, ownerId, scheduleType, scheduleDetails);
+    }
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/ScheduleType.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/ScheduleType.java
@@ -1,0 +1,5 @@
+package com.lovely4k.backend.calendar;
+
+public enum ScheduleType {
+    TRAVEL, DATE, ANNIVERSARY, PERSONAL, ETC
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/CalendarCommandRepository.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/CalendarCommandRepository.java
@@ -1,0 +1,7 @@
+package com.lovely4k.backend.calendar.repository;
+
+import com.lovely4k.backend.calendar.Calendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CalendarCommandRepository extends JpaRepository<Calendar, Long> {
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/CalendarQueryRepository.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/CalendarQueryRepository.java
@@ -1,0 +1,7 @@
+package com.lovely4k.backend.calendar.repository;
+
+import com.lovely4k.backend.calendar.Calendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CalendarQueryRepository extends JpaRepository<Calendar, Long> {
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/response/ColorResponse.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/response/ColorResponse.java
@@ -1,0 +1,7 @@
+package com.lovely4k.backend.calendar.repository.response;
+
+public record ColorResponse(
+        long memberId,
+        String calendarColor
+) {
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/response/FindAllCalendarsWithDateResponse.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/response/FindAllCalendarsWithDateResponse.java
@@ -1,0 +1,11 @@
+package com.lovely4k.backend.calendar.repository.response;
+
+import java.util.List;
+
+public record FindAllCalendarsWithDateResponse(
+        ColorResponse firstColor,
+        ColorResponse secondColor,
+        List<ScheduleResponse> schedules
+
+) {
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/response/FindRecentCalendarsResponse.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/response/FindRecentCalendarsResponse.java
@@ -1,0 +1,10 @@
+package com.lovely4k.backend.calendar.repository.response;
+
+import java.util.List;
+
+public record FindRecentCalendarsResponse(
+        ColorResponse firstColor,
+        ColorResponse secondColor,
+        List<ScheduleResponse> schedules
+) {
+}

--- a/model/src/main/java/com/lovely4k/backend/calendar/repository/response/ScheduleResponse.java
+++ b/model/src/main/java/com/lovely4k/backend/calendar/repository/response/ScheduleResponse.java
@@ -1,0 +1,13 @@
+package com.lovely4k.backend.calendar.repository.response;
+
+import com.lovely4k.backend.calendar.ScheduleType;
+
+import java.time.LocalDate;
+
+public record ScheduleResponse(
+        LocalDate startDate,
+        LocalDate endDate,
+        String scheduleDetails,
+        ScheduleType scheduleType
+) {
+}


### PR DESCRIPTION
## 🚀 Pull Request Template 🚀

### 📝 변경 이유 (Why did you make these changes?)

<!-- 여기에 변경 이유를 적어주세요-->
- 엔드포인는 총 5개 입니다.
- 최근 일정 조회 (쿼리 파라미터로 limit만 받고 조회시 mysql 내장 함수 이용해서 조회할 예정, 추후 mysql 서버 시간도 변경해야 함)
```
SELECT * 
FROM calendar 
WHERE date >= CURDATE() 
ORDER BY date ASC 
LIMIT :=limit;
```
- 일정 시작일 기준으로 조회 (ex: 2023-01-01~2023-11-02 까지의 일정 조회)
- 일정 생성, 삭제, 수정
---

### ⚠️ 발견된 위험 또는 장애 (Identified Risks or Issues)

<!-- 발견된 위험이나 장애가 있다면 여기에 기록해주세요.-->

---

### 👀 리뷰 포커스 (Review Focus)

<!-- 리뷰어가 집중해야 할 부분을 알려주세요.-->
- Schedule과 Calendar 라는 네이밍이 혼용되어 헷갈릴 것 같네요.
-  먼저 **사용자 측**에서 보기에는 이 기능은 **Calendar 기능**(눈으로 봤을 때 달력이 너무 잘보여서) 이라고 볼 수 있겠지만 **서버 단에서 구현하는 기능**으로 보면 일정 관리에 가깝습니다. 따라서 **프론트** 쪽에 **응답**할 때는 **Schedule이라는 네이밍**(컨르롤러에서)을 썼고 **Service 안**으로 들어가면 **Entity 이름에 맞는 Calendar**라는 네이밍을 했습니다. 애매하긴 하네요 Schedule이라고 짓기에는 달력이 전혀 떠오르지 않아서 이렇게 네이밍을 하기는 했는데..

1. 명령과 조회 서비스를 나눴습니다.
2. 두 서비스는 주입받는 repository가 다른데 둘 다 JPA 리포지토리를 쓰기는 했습니다.
3. Service 코드에 findAll 메소드가 한번 씩 호출이 되는데 ArchTest 중 Service 클래스 의존성 테스트가 repsoitory 클래스의 메소드를 호출하는 시점에서 의존성을 파악하기 때문에 임시로 findAll 메소드를 한개 넣었습니다.
4. 날짜 관련해서 JsonFormat과 DateTimeFormat을 사용했는데 자세한 내용은 [여기](https://jojoldu.tistory.com/361) 있습니다.
  - 요약하자면 JsonFormat은 직렬화 역직렬화와 관련한 어노테이션이고, DateTimeFormat은 날짜 형식의 클래스를 문자열로 변환하는것에 대한 어노테이션입니다. jsonFormat은 jackson 라이브러리에 의존하며 DateTimeFormat은 spring에서 제공하는 라이브러리 입니다.
5. 조회 로직은 select * 이 아닌 필요한 필드를 하나씩 프로젝션으로 받을 생각인데 이 때 dto는 model 모듈에 있습니다. 따라서@JsonFormat을 적용할 수 없기 때문에 (jackson은 spring-mvc 라이브러리에 있음) api 모듈에서 model의 dto를 한번 받고 이를 @JsonFormat으로 날짜를 변환해주기 위해 FindXXXReponse dto가 service 패키지 안에 존재합니다.
6. from 메소드와 기본 생성자를 혼용해서 사용했는데 기능 추가하면서 일관적으로 맞추겠습니다.

이상무~~~
---

### ✅ 테스트 계획 및 완료 사항 (Test Plans & Completed Items)

<!-- 테스트 계획과 완료한 사항을 여기에 적어주세요.-->

---

### :octocat: 기타 사항

<!-- 필요하다면 기타 전달하고 싶은 내용을 작성해주세요-->

🙏 리뷰해 주셔서 감사합니다! 🙏
