### PR TITLE
refactor : 커플 프로필 조회 시 만난날 추가 및 @JsonFormat 추가 (release1.1 -> dev)

### DIFF
--- a/api/src/main/java/com/lovely4k/backend/couple/service/CoupleService.java
+++ b/api/src/main/java/com/lovely4k/backend/couple/service/CoupleService.java
@@ -55,7 +55,7 @@ public class CoupleService {
         Member boy = findMember(couple.getBoyId());
         Member girl = findMember(couple.getGirlId());
 
-        return CoupleProfileGetResponse.from(boy, girl);
+        return CoupleProfileGetResponse.from(boy, girl, couple.getMeetDay());
     }
 
     @Transactional

--- a/api/src/main/java/com/lovely4k/backend/couple/service/response/CoupleProfileGetResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/couple/service/response/CoupleProfileGetResponse.java
@@ -1,6 +1,9 @@
 package com.lovely4k.backend.couple.service.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lovely4k.backend.member.Member;
+
+import java.time.LocalDate;
 
 public record CoupleProfileGetResponse(
     String boyNickname,
@@ -8,16 +11,18 @@ public record CoupleProfileGetResponse(
     String girlNickname,
     String girlMbti,
     String boyImageUrl,
-    String girlImageUrl
+    String girlImageUrl,
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    LocalDate meetDay
 ) {
-    public static CoupleProfileGetResponse from(Member boy, Member girl) {
+    public static CoupleProfileGetResponse from(Member boy, Member girl, LocalDate meetDay) {
         return new CoupleProfileGetResponse(
             boy.getNickname(),
             boy.getMbti(),
             girl.getNickname(),
             girl.getMbti(),
             boy.getImageUrl(),
-            girl.getImageUrl());
+            girl.getImageUrl(),
+            meetDay);
     }
-
 }

--- a/api/src/main/java/com/lovely4k/backend/diary/service/response/DiaryDetailResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/diary/service/response/DiaryDetailResponse.java
@@ -1,5 +1,6 @@
 package com.lovely4k.backend.diary.service.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lovely4k.backend.diary.Diary;
 import com.lovely4k.backend.location.Category;
 
@@ -7,6 +8,7 @@ import java.time.LocalDate;
 
 public record DiaryDetailResponse(
         Long kakaoMapId,
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate datingDay,
         Integer score,
         Category category,

--- a/api/src/main/java/com/lovely4k/backend/member/service/response/MemberProfileGetResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/member/service/response/MemberProfileGetResponse.java
@@ -1,5 +1,6 @@
 package com.lovely4k.backend.member.service.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.lovely4k.backend.member.Member;
 
 import java.time.LocalDate;
@@ -8,6 +9,7 @@ public record MemberProfileGetResponse(
     String imageUrl,
     String name,
     String nickname,
+    @JsonFormat(pattern = "yyyy-MM-dd")
     LocalDate birthday,
     String mbti,
     String calendarColor

--- a/api/src/test/java/com/lovely4k/backend/couple/controller/CoupleControllerTest.java
+++ b/api/src/test/java/com/lovely4k/backend/couple/controller/CoupleControllerTest.java
@@ -8,6 +8,7 @@ import com.lovely4k.backend.member.Sex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import static org.mockito.BDDMockito.given;
@@ -71,7 +72,8 @@ class CoupleControllerTest extends ControllerTestSupport {
                 "깜찍이",
                 "INFP",
                 "boyProfileUrl",
-                "girlProfile,Url"
+                "girlProfile,Url",
+                LocalDate.of(2020, 7, 23)
             ));
 
         //when //then

--- a/api/src/test/java/com/lovely4k/docs/couple/CoupleControllerDocsTest.java
+++ b/api/src/test/java/com/lovely4k/docs/couple/CoupleControllerDocsTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDate;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -119,7 +121,8 @@ class CoupleControllerDocsTest extends RestDocsSupport {
                 "깜찍이",
                 "INFP",
                 "boyProfileUrl",
-                "girlProfileUrl"
+                "girlProfileUrl",
+                LocalDate.of(2020, 7, 23)
             )
         );
 
@@ -147,6 +150,8 @@ class CoupleControllerDocsTest extends RestDocsSupport {
                             .description("남자친구 프로필 사진 url"),
                         fieldWithPath("body.girlImageUrl").type(JsonFieldType.STRING)
                             .description("여자친구 프로필 사진 url"),
+                        fieldWithPath("body.meetDay").type(JsonFieldType.STRING)
+                            .description("만난날"),
                         fieldWithPath("links[0].rel").type(JsonFieldType.STRING)
                             .description("relation of url"),
                         fieldWithPath("links[0].href").type(JsonFieldType.STRING)

--- a/api/src/test/java/com/lovely4k/docs/diary/DiaryControllerDocsTest.java
+++ b/api/src/test/java/com/lovely4k/docs/diary/DiaryControllerDocsTest.java
@@ -123,7 +123,7 @@ class DiaryControllerDocsTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("code").type(NUMBER).description("코드"),
                                 fieldWithPath("body.kakaoMapId").type(NUMBER).description("카카오 장소 id"),
-                                fieldWithPath("body.datingDay").type(ARRAY).description("데이트 날짜"),
+                                fieldWithPath("body.datingDay").type(STRING).description("데이트 날짜"),
                                 fieldWithPath("body.score").type(NUMBER).description("장소에 대한 평점"),
                                 fieldWithPath("body.category").type(STRING).description("장소 카테고리"),
                                 fieldWithPath("body.boyText").type(STRING).description("남자친구 다이어리 내용"),

--- a/api/src/test/java/com/lovely4k/docs/member/MemberControllerDocsTest.java
+++ b/api/src/test/java/com/lovely4k/docs/member/MemberControllerDocsTest.java
@@ -64,7 +64,7 @@ class MemberControllerDocsTest extends RestDocsSupport {
                             .description("이름"),
                         fieldWithPath("body.nickname").type(JsonFieldType.STRING)
                             .description("별명"),
-                        fieldWithPath("body.birthday").type(JsonFieldType.ARRAY)
+                        fieldWithPath("body.birthday").type(JsonFieldType.STRING)
                             .description("생년월일"),
                         fieldWithPath("body.mbti").type(JsonFieldType.STRING)
                             .description("MBTI"),


### PR DESCRIPTION
## 🚀 Pull Request Template 🚀

### 📝 변경 이유 (Why did you make these changes?)

<!-- 여기에 변경 이유를 적어주세요-->

- 프론트 분들이 요청
  - 응답 시 날짜 필드 패턴 수정 요청 e.g) "2020-09-12"
  - 커플 프로필 조회 시 만난날 추가
---

### ⚠️ 발견된 위험 또는 장애 (Identified Risks or Issues)

<!-- 발견된 위험이나 장애가 있다면 여기에 기록해주세요.-->
- 없습니다.
---

### 👀 리뷰 포커스 (Review Focus)

<!-- 리뷰어가 집중해야 할 부분을 알려주세요.-->
- 응답 DTO내에서 LocalDate 타입의 경우 @JsonFormat을 사용하였습니다.
  - 위의 변경에 따른 Conroller테스트 및 restdocs테스트 수정이 있습니다.
- 커플 프로필 조회시 응답 DTO에 만난날 필드를 추가하였습니다.
---

### ✅ 테스트 계획 및 완료 사항 (Test Plans & Completed Items)

<!-- 테스트 계획과 완료한 사항을 여기에 적어주세요.-->
- 테스트 완료하였습니다.
---

### :octocat: 기타 사항

<!-- 필요하다면 기타 전달하고 싶은 내용을 작성해주세요-->

🙏 리뷰해 주셔서 감사합니다! 🙏
