### PR TITLE
feat : 커플 맺어졌을 때, 회원 정보가 변경되었을 때 로그아웃 없이 세션 정보 변경 기능 추가

### DIFF
--- a/api/src/main/java/com/lovely4k/backend/authentication/MyOAuth2Member.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/MyOAuth2Member.java
@@ -29,10 +29,10 @@ public class MyOAuth2Member implements OAuth2User, Serializable, MemberInfo {
     private final String nameAttributeKey;
 
     private final Long memberId;
-    private final Long coupleId;
+    private Long coupleId;
     private final Sex sex;
-    private final String nickName;
-    private final String picture;
+    private String nickName;
+    private String picture;
 
     /**
      * Constructs a {@code DefaultOAuth2User} using the provided parameters.
@@ -81,6 +81,14 @@ public class MyOAuth2Member implements OAuth2User, Serializable, MemberInfo {
             Comparator.comparing(GrantedAuthority::getAuthority));
         sortedAuthorities.addAll(authorities);
         return sortedAuthorities;
+    }
+
+    public MyOAuth2Member update(Long coupleId, String nickName, String picture) {
+        this.coupleId = coupleId;
+        this.nickName = nickName;
+        this.picture = picture;
+
+        return this;
     }
 
 }

--- a/api/src/main/java/com/lovely4k/backend/authentication/SessionInfoUpdateHandler.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/SessionInfoUpdateHandler.java
@@ -1,0 +1,89 @@
+package com.lovely4k.backend.authentication;
+
+import com.lovely4k.backend.couple.Couple;
+import com.lovely4k.backend.couple.CoupleCreatedEvent;
+import com.lovely4k.backend.couple.CoupleUpdatedEvent;
+import com.lovely4k.backend.member.Member;
+import com.lovely4k.backend.member.MemberupdatedEvent;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class SessionInfoUpdateHandler {
+
+    private final HttpSession httpSession;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateSessionAfterMemberUpdatedEvent(MemberupdatedEvent event) {
+        Member member = event.member();
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            MyOAuth2Member principal = (MyOAuth2Member) authentication.getPrincipal();
+            OAuth2AuthenticationToken oAuth2AuthenticationToken =
+                new OAuth2AuthenticationToken(
+                    principal.update(
+                        member.getCoupleId(),
+                        member.getNickname(),
+                        member.getImageUrl()
+                    ),
+                    authentication.getAuthorities(),
+                    principal.getNameAttributeKey()
+                );
+
+            SecurityContextHolder.getContext().setAuthentication(oAuth2AuthenticationToken);
+
+            SecurityContext securityContext = SecurityContextHolder.getContext();
+            httpSession.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateSessionAfterCoupleCreatedEvent(CoupleCreatedEvent event) {
+        Couple couple = event.couple();
+        updateSessionWithCouple(couple);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateSessionAfterCoupleUpdatedEvent(CoupleUpdatedEvent event) {
+        Couple couple = event.couple();
+        updateSessionWithCouple(couple);
+    }
+
+
+    private void updateSessionWithCouple(Couple couple) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            MyOAuth2Member principal = (MyOAuth2Member) authentication.getPrincipal();
+            OAuth2AuthenticationToken oAuth2AuthenticationToken =
+                new OAuth2AuthenticationToken(
+                    principal.update(
+                        couple.getId(),
+                        principal.getNickName(),
+                        principal.getPicture()
+                    ),
+                    authentication.getAuthorities(),
+                    principal.getNameAttributeKey()
+                );
+
+            SecurityContextHolder.getContext().setAuthentication(oAuth2AuthenticationToken);
+
+            SecurityContext securityContext = SecurityContextHolder.getContext();
+            httpSession.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+        }
+
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/couple/service/CoupleService.java
+++ b/api/src/main/java/com/lovely4k/backend/couple/service/CoupleService.java
@@ -2,6 +2,8 @@ package com.lovely4k.backend.couple.service;
 
 import com.lovely4k.backend.common.ExceptionMessage;
 import com.lovely4k.backend.couple.Couple;
+import com.lovely4k.backend.couple.CoupleCreatedEvent;
+import com.lovely4k.backend.couple.CoupleUpdatedEvent;
 import com.lovely4k.backend.couple.repository.CoupleRepository;
 import com.lovely4k.backend.couple.service.request.CoupleProfileEditServiceRequest;
 import com.lovely4k.backend.couple.service.response.CoupleProfileGetResponse;
@@ -11,6 +13,7 @@ import com.lovely4k.backend.member.Sex;
 import com.lovely4k.backend.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +27,7 @@ public class CoupleService {
 
     private final CoupleRepository coupleRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public InvitationCodeCreateResponse
@@ -32,7 +36,7 @@ public class CoupleService {
 
         Couple couple = Couple.create(requestedMemberId, Sex.valueOf(sex), invitationCode);
         Couple savedCouple = coupleRepository.save(couple);
-
+        eventPublisher.publishEvent(new CoupleCreatedEvent(couple));
         return new InvitationCodeCreateResponse(savedCouple.getId(), invitationCode);
     }
 
@@ -45,8 +49,8 @@ public class CoupleService {
         } else {
             couple.registerGirlId(receivedMemberId);
         }
-
         registerCoupleId(couple);
+        eventPublisher.publishEvent(new CoupleUpdatedEvent(couple));
     }
 
     public CoupleProfileGetResponse findCoupleProfile(Long memberId) {

--- a/api/src/main/java/com/lovely4k/backend/member/service/MemberService.java
+++ b/api/src/main/java/com/lovely4k/backend/member/service/MemberService.java
@@ -2,11 +2,13 @@ package com.lovely4k.backend.member.service;
 
 import com.lovely4k.backend.common.imageuploader.ImageUploader;
 import com.lovely4k.backend.member.Member;
+import com.lovely4k.backend.member.MemberupdatedEvent;
 import com.lovely4k.backend.member.repository.MemberRepository;
 import com.lovely4k.backend.member.service.request.MemberProfileEditServiceRequest;
 import com.lovely4k.backend.member.service.response.MemberProfileGetResponse;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +22,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final ImageUploader imageUploader;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     public MemberProfileGetResponse findMemberProfile(Long memberId) {
@@ -37,6 +40,7 @@ public class MemberService {
         String profileImageUrl = updateProfileImage(profileImages, oldProfileImageUrl);
 
         updateMemberProfile(profileImageUrl, serviceRequest, findMember);
+        eventPublisher.publishEvent(new MemberupdatedEvent(findMember));
     }
 
     private String updateProfileImage(List<MultipartFile> profileImages, String oldProfileImageUrl) {

--- a/api/src/test/java/com/lovely4k/backend/authentication/SessionInfoUpdateHandlerTest.java
+++ b/api/src/test/java/com/lovely4k/backend/authentication/SessionInfoUpdateHandlerTest.java
@@ -1,0 +1,147 @@
+package com.lovely4k.backend.authentication;
+
+import com.lovely4k.backend.couple.Couple;
+import com.lovely4k.backend.couple.CoupleCreatedEvent;
+import com.lovely4k.backend.couple.CoupleUpdatedEvent;
+import com.lovely4k.backend.member.Member;
+import com.lovely4k.backend.member.MemberupdatedEvent;
+import com.lovely4k.backend.member.Role;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionInfoUpdateHandlerTest {
+
+    @Mock
+    HttpSession httpSession;
+
+    @InjectMocks
+    SessionInfoUpdateHandler sessionInfoUpdateHandler;
+
+
+    @DisplayName("커플이 invitaion 코드가 생성되면 invitaion 코드를 발급한 유저의 세션 정보가 업데이트 된다.")
+    @Test
+    void test2() {
+
+        //given
+        Couple couple = Mockito.mock(Couple.class);
+        given(couple.getId()).willReturn(1L);
+        Member member = Member.builder().coupleId(1L).imageUrl("testUrl").nickname("nickName").role(Role.GUEST).coupleId(1L).build();
+
+        CoupleCreatedEvent event = new CoupleCreatedEvent(couple);
+        MyOAuth2Member principal = new MyOAuth2Member(Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())), "test", member);
+
+
+        OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+            principal, principal.getAuthorities(), principal.getNameAttributeKey()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        //when
+        sessionInfoUpdateHandler.updateSessionAfterCoupleCreatedEvent(event);
+
+        //then
+        verify(httpSession).setAttribute(
+            eq(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY),
+            any(SecurityContext.class)
+        );
+
+        OAuth2AuthenticationToken updatedAuthentication =
+            (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        assertAll(
+            () -> assertThat(updatedAuthentication).isNotNull(),
+            () -> assertThat(updatedAuthentication.getPrincipal()).isInstanceOf(MyOAuth2Member.class),
+            () -> assertThat(((MyOAuth2Member) updatedAuthentication.getPrincipal()).getCoupleId()).isEqualTo(member.getCoupleId())
+        );
+    }
+
+    @DisplayName("커플이 맺어지면 invitaion 코드를 받은 유저의 세션 정보가 업데이트 된다")
+    @Test
+    void updateSessionAfterCoupleUpdatedEvent() {
+
+        //given
+        Couple couple = Mockito.mock(Couple.class);
+        given(couple.getId()).willReturn(1L);
+        Member member = Member.builder().coupleId(1L).imageUrl("testUrl").nickname("nickName").role(Role.GUEST).coupleId(1L).build();
+
+        CoupleUpdatedEvent event = new CoupleUpdatedEvent(couple);
+        MyOAuth2Member principal = new MyOAuth2Member(Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())), "test", member);
+
+
+        OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+            principal, principal.getAuthorities(), principal.getNameAttributeKey()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        sessionInfoUpdateHandler.updateSessionAfterCoupleUpdatedEvent(event);
+
+        // then
+        verify(httpSession).setAttribute(
+            eq(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY),
+            any(SecurityContext.class)
+        );
+
+
+        OAuth2AuthenticationToken updatedAuthentication =
+            (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        assertAll(
+            () -> assertThat(updatedAuthentication).isNotNull(),
+            () -> assertThat(updatedAuthentication.getPrincipal()).isInstanceOf(MyOAuth2Member.class),
+            () -> assertThat(((MyOAuth2Member) updatedAuthentication.getPrincipal()).getCoupleId()).isEqualTo(member.getCoupleId())
+        );
+    }
+
+    @DisplayName("사용자 정보가 바뀌면 로그아웃 없이 세션 정보가 업데이트 된다.")
+    @Test
+    void whenMemberUpdatedEvent_thenAuthenticationShouldBeUpdated() {
+        // given
+        Member member = Member.builder().coupleId(1L).imageUrl("testUrl").nickname("nickName").role(Role.GUEST).build();
+
+        MemberupdatedEvent event = new MemberupdatedEvent(member);
+        MyOAuth2Member principal = new MyOAuth2Member(Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())), "test", member);
+
+
+        OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+            principal, principal.getAuthorities(), principal.getNameAttributeKey()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        sessionInfoUpdateHandler.updateSessionAfterMemberUpdatedEvent(event);
+
+        // then
+        verify(httpSession).setAttribute(
+            eq(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY),
+            any(SecurityContext.class)
+        );
+
+        OAuth2AuthenticationToken updatedAuthentication =
+            (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        assertAll(
+            () -> assertThat(updatedAuthentication).isNotNull(),
+            () -> assertThat(updatedAuthentication.getPrincipal()).isInstanceOf(MyOAuth2Member.class),
+            () -> assertThat(((MyOAuth2Member) updatedAuthentication.getPrincipal()).getCoupleId()).isEqualTo(member.getCoupleId())
+        );
+    }
+}

--- a/model/src/main/java/com/lovely4k/backend/couple/CoupleCreatedEvent.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/CoupleCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.lovely4k.backend.couple;
+
+public record CoupleCreatedEvent(
+    Couple couple
+) {
+}

--- a/model/src/main/java/com/lovely4k/backend/couple/CoupleUpdatedEvent.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/CoupleUpdatedEvent.java
@@ -1,0 +1,6 @@
+package com.lovely4k.backend.couple;
+
+public record CoupleUpdatedEvent(
+    Couple couple
+) {
+}

--- a/model/src/main/java/com/lovely4k/backend/member/MemberupdatedEvent.java
+++ b/model/src/main/java/com/lovely4k/backend/member/MemberupdatedEvent.java
@@ -1,0 +1,6 @@
+package com.lovely4k.backend.member;
+
+public record MemberupdatedEvent(
+    Member member
+) {
+}


### PR DESCRIPTION
## 🚀 Pull Request Template 🚀

### 📝 변경 이유 (Why did you make these changes?)

<!-- 여기에 변경 이유를 적어주세요-->

---

### ⚠️ 발견된 위험 또는 장애 (Identified Risks or Issues)

<!-- 발견된 위험이나 장애가 있다면 여기에 기록해주세요.-->

---

### 👀 리뷰 포커스 (Review Focus)

<!-- 리뷰어가 집중해야 할 부분을 알려주세요.-->
- 사용자 정보가 변경 됐을 때 로그아웃 없이 세션 정보가 업데이트 되도록 했습니다.
- 서비스 간 결합도를 이벤트를 이용해 느슨하게 했습니다.
- SecurityContext는 스레드 로컬에 저장되기 때문에 동기적으로 작성했습니다.
---

### ✅ 테스트 계획 및 완료 사항 (Test Plans & Completed Items)

<!-- 테스트 계획과 완료한 사항을 여기에 적어주세요.-->

---

### :octocat: 기타 사항

<!-- 필요하다면 기타 전달하고 싶은 내용을 작성해주세요-->

🙏 리뷰해 주셔서 감사합니다! 🙏
