### PR TITLE
feat : refresh토큰 발급 추가

### DIFF
--- a/api/src/main/java/com/lovely4k/backend/authentication/CustomSuccessHandler.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/CustomSuccessHandler.java
@@ -64,7 +64,7 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
         response.setHeader("Location", redirectUrl);
         try {
-            response.sendRedirect(redirectUrl + "?token=" + tokenDto.accessToken() + "&recouple-url=" + recoupleUrl + "&refreshToken=" + tokenDto.refreshToken());
+            response.sendRedirect(redirectUrl + "?accessToken=" + tokenDto.accessToken() +"&refreshToken=" + tokenDto.refreshToken() + "&recouple-url=" + recoupleUrl);
         } catch (IOException e) {
             throw new IllegalStateException("Something went wrong while generating response message", e);
         }
@@ -74,7 +74,7 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
         response.setHeader("Location", redirectUrl);
         try {
-            response.sendRedirect(redirectUrl + "?token=" + tokenDto.accessToken() + "&refreshToken=" + tokenDto.refreshToken());
+            response.sendRedirect(redirectUrl + "?accessToken=" + tokenDto.accessToken() + "&refreshToken=" + tokenDto.refreshToken());
         } catch (IOException e) {
             throw new IllegalStateException("Something went wrong while generating response message", e);
         }

--- a/api/src/main/java/com/lovely4k/backend/authentication/CustomSuccessHandler.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/CustomSuccessHandler.java
@@ -45,32 +45,36 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         optionalCouple.ifPresentOrElse(
             couple -> {
                 if (couple.isRecoupleReceiver(oAuth2Member.getMemberId())) {
-                    sendRecoupleCode(response, tokenDto.accessToken());
+
+                    log.debug("send code!!");
+                    sendRecoupleCode(response, coupleId, tokenDto);
                 } else {
-                    sendCode(response, tokenDto.accessToken());
+                    sendCode(response, tokenDto);
                 }
             }
-            , () -> sendCode(response, tokenDto.accessToken())
+            , () -> sendCode(response, tokenDto)
         );
 
     }
 
-    private void sendRecoupleCode(HttpServletResponse response, String accessToken) {
-        String recoupleUrl = redirectUrl + "recouple";
+
+    private void sendRecoupleCode(HttpServletResponse response, Long coupleId, TokenDto tokenDto) {
+        String recoupleUrl = redirectUrl + "recouple/" + coupleId;
+
         response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
         response.setHeader("Location", redirectUrl);
         try {
-            response.sendRedirect(redirectUrl + "?token=" + accessToken + "&recouple-url=" + recoupleUrl);
+            response.sendRedirect(redirectUrl + "?token=" + tokenDto.accessToken() + "&recouple-url=" + recoupleUrl + "&refreshToken=" + tokenDto.refreshToken());
         } catch (IOException e) {
             throw new IllegalStateException("Something went wrong while generating response message", e);
         }
     }
 
-    private void sendCode(HttpServletResponse response, String accessToken) {
+    private void sendCode(HttpServletResponse response, TokenDto tokenDto) {
         response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
         response.setHeader("Location", redirectUrl);
         try {
-            response.sendRedirect(redirectUrl +"?token=" + accessToken);
+            response.sendRedirect(redirectUrl + "?token=" + tokenDto.accessToken() + "&refreshToken=" + tokenDto.refreshToken());
         } catch (IOException e) {
             throw new IllegalStateException("Something went wrong while generating response message", e);
         }

--- a/api/src/main/java/com/lovely4k/backend/authentication/exception/InvalidateTokenResponseWriter.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/exception/InvalidateTokenResponseWriter.java
@@ -1,0 +1,50 @@
+package com.lovely4k.backend.authentication.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.security.Key;
+import java.util.Map;
+
+@Slf4j
+public class InvalidateTokenResponseWriter {
+
+    public static void write(Key key, String token, HttpServletResponse response, ObjectMapper objectMapper) throws IOException {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            log.debug("만료된 JWT 토큰!!!!!!");
+            expiredTokenResponse(response, objectMapper, e);
+            throw new IllegalArgumentException("만료된 토큰");
+        } catch (Exception e) {
+            log.debug("잘못된 JWT 토큰!!!!!!!");
+            invalidTokenResponse(response, objectMapper, e);
+            throw new IllegalArgumentException("잘못된 토큰");
+        }
+    }
+
+    private static void expiredTokenResponse(HttpServletResponse response, ObjectMapper objectMapper, Exception e) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().println(
+            objectMapper.writeValueAsString(
+                Map.of("예외", "토큰 만료", "메시지", e.getMessage())
+            )
+        );
+    }
+
+    private static void invalidTokenResponse(HttpServletResponse response, ObjectMapper objectMapper, Exception e) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().println(
+            objectMapper.writeValueAsString(
+                Map.of("예외", "잘못된 토큰", "메시지", e.getMessage())
+            )
+        );
+    }
+
+}

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/JwtFilter.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/JwtFilter.java
@@ -1,6 +1,8 @@
 package com.lovely4k.backend.authentication.token;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lovely4k.backend.authentication.RefreshToken;
+import com.lovely4k.backend.authentication.exception.InvalidateTokenResponseWriter;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -12,90 +14,102 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.util.AntPathMatcher;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.security.Key;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
+@Component
 public class JwtFilter extends OncePerRequestFilter {
 
     public static String AUTHORIZATION_HEADER = "Authorization";    // NOSONAR
     public static String BEARER_PREFIX = "Bearer ";     // NOSONAR
     public static String AUTHORITIES_KEY = "auth";      // NOSONAR
-    private final String SECRET_KEY;                    // NOSONAR
+    private static final String REFRESH_HEADER = "Refresh";
     private final TokenProvider tokenProvider;
     private final UserDetailsServiceImpl userDetailsService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;      // NOSONAR
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws IOException, ServletException {
-        // OAuth 관련 경로를 여기에 지정합니다.
-        String[] allowedPaths = new String[] {
-            "/login/**",
-            "/oauth2/authorization/**"
-        };
 
-        // 현재 요청의 경로
-        String requestPath = request.getRequestURI();
-
-        // OAuth 관련 경로인 경우 필터를 건너뜁니다.
-        for (String pattern : allowedPaths) {
-            if (new AntPathMatcher().match(pattern, requestPath)) {
-                filterChain.doFilter(request, response);
-                return; // 필터 체인의 다음 필터로 요청을 넘기고 현재 필터의 작업을 종료합니다.
-            }
+        String refreshKey = resolveRefresh(request);
+        if (StringUtils.hasText(refreshKey)) {
+            sendAccessToken(response, refreshKey);
+            return;
         }
-
-        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
-        Key key = Keys.hmacShaKeyFor(keyBytes);
 
         String jwt = resolveToken(request);
 
-        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            log.debug("if 분기문 안 로직 ");
-            Claims claims;
+        if (StringUtils.hasText(jwt)) {
             try {
-                claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwt).getBody();
-            } catch (ExpiredJwtException e) {
-                claims = e.getClaims();
+                byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+                Key key = Keys.hmacShaKeyFor(keyBytes);
+                InvalidateTokenResponseWriter.write(key, jwt, response, objectMapper); //바디에 잘못된 토큰 쓰기
+                log.debug("if 분기문 안 로직 ");
+                Claims claims = resolveClaims(jwt); //jwt 토큰으로부터 Claim을 얻어 옴 Claim 내에는 사용자의 email이 들어있음
+                updateSecurityContext(claims, jwt); //claim에 들어있는 email로 멤버를 조회해서 SecurityContext에 Member 넣기
+            } catch (Exception e) {
+                return; //예외는 InvalidateTokenResponseWriter.write(key, jwt, response, objectMapper); 여기서 상세 메시지 바디에 쓰고 예외 던짐
             }
-
-            if (claims.getExpiration().toInstant().toEpochMilli() < Instant.now().toEpochMilli()) {
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().println(
-                    new ObjectMapper().writeValueAsString(
-                        //ResponseDto
-                        ("BAD_REQUEST"+ "Token 이 유효하지 않습니다.")
-                    )
-                );
-                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            }
-
-            String subject = claims.getSubject();
-            Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                    .map(SimpleGrantedAuthority::new)
-                    .toList();
-            log.debug("subject = " + subject);
-            UserDetails principal = userDetailsService.loadUserByUsername(subject);
-            log.debug("principal = " + principal);
-            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, jwt, authorities);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         filterChain.doFilter(request, response);
+    }
+
+    private void updateSecurityContext(Claims claims, String jwt) {
+        String subject = claims.getSubject();
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+        log.debug("subject = " + subject);
+        UserDetails principal = userDetailsService.loadUserByUsername(subject);
+        log.debug("principal = " + principal);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, jwt, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private Claims resolveClaims(String jwt) {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
+        Claims claims;
+        try {
+            claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwt).getBody();
+        } catch (ExpiredJwtException e) {
+            log.debug("토큰 만료 예외 clamims: {}", e.getClaims());
+            claims = e.getClaims();
+        }
+        return claims;
+    }
+
+    private void sendAccessToken(HttpServletResponse response, String refreshKey) throws IOException {
+        RefreshToken refreshToken = tokenProvider.findRefreshTokenByKeyValue(refreshKey);
+        String jwt = tokenProvider.generateAccessToken(refreshToken.getMember());
+        response.getWriter().println(
+            objectMapper.writeValueAsString(
+                Map.of("accessToken", jwt)
+            )
+        );
+
+        log.debug("업데이트 된 jwt: {}", jwt);
     }
 
     private String resolveToken(HttpServletRequest request) {
@@ -103,6 +117,15 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private String resolveRefresh(HttpServletRequest request) {
+        log.debug("리프레시 토큰 헤더: {}", request.getHeader(REFRESH_HEADER));
+        String refreshToken = request.getHeader(REFRESH_HEADER);
+        if (StringUtils.hasText(refreshToken)) {
+            return refreshToken;
         }
         return null;
     }

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/JwtFilter.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/JwtFilter.java
@@ -39,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
     public static String AUTHORIZATION_HEADER = "Authorization";    // NOSONAR
     public static String BEARER_PREFIX = "Bearer ";     // NOSONAR
     public static String AUTHORITIES_KEY = "auth";      // NOSONAR
-    private static final String REFRESH_HEADER = "Refresh";
+    private static final String REFRESH_HEADER = "Refresh-Token";
     private final TokenProvider tokenProvider;
     private final UserDetailsServiceImpl userDetailsService;
     private final ObjectMapper objectMapper;

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/SecurityConfig.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/SecurityConfig.java
@@ -5,7 +5,6 @@ import com.lovely4k.backend.authentication.OAuth2UserService;
 import com.lovely4k.backend.authentication.exception.AccessDeniedHandlerException;
 import com.lovely4k.backend.authentication.exception.AuthenticationEntryPointException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,20 +22,17 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
 @RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
 
-    @Value("${jwt.secret}")
-    private String SECRET_KEY;
     private final OAuth2UserService oAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final TokenProvider tokenProvider;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationEntryPointException authenticationEntryPointException;
     private final AccessDeniedHandlerException accessDeniedHandlerException;
+    private final JwtFilter jwtFilter;
 
     @Bean
     @Order(SecurityProperties.BASIC_AUTH_ORDER)
@@ -53,17 +49,16 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests(
                 authorize -> authorize
-                    .requestMatchers(
-                        antMatcher("/h2-console"),
-                        antMatcher("/v1/**")
-                    ).permitAll()
-
-//                    .requestMatchers(
-//                        antMatcher("/v1/**")
-//                    ).hasRole(Role.USER.name())
-
                     .anyRequest().permitAll()
             );
+        //권한 추가되면 사용
+//        .authorizeHttpRequests(
+//            authorize -> authorize
+//                .requestMatchers(
+//                    antMatcher("/v1/**")
+//                ).hasRole(Role.USER.name())
+//                .anyRequest().permitAll()
+//        );
 
         // 로그아웃 설정
         http
@@ -101,7 +96,7 @@ public class SecurityConfig {
         ;
 
         http
-            .addFilterBefore(new JwtFilter(SECRET_KEY, tokenProvider, userDetailsService), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
         ;
 
         // Session 설정

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/TokenProvider.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/TokenProvider.java
@@ -13,15 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.Key;
 import java.util.Date;
-import java.util.Optional;
 
 @Slf4j
 @Component
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_PREFIX = "Bearer ";
-//    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
-    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30 * 2 * 24;            // 1일
+    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+//    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30 * 2 * 24;            // 1일
     private static final int REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;     //7일
 
     private final Key key;
@@ -62,26 +61,20 @@ public class TokenProvider {
         return new TokenDto(BEARER_PREFIX, accessToken, refreshToken, accessTokenExpiresIn.getTime());
     }
 
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT token, 만료된 JWT token 입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
-        } catch (IllegalArgumentException e) {
-            log.info("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
-        }
-        return false;
+    public String generateAccessToken(Member member) {
+        long now = (new Date().getTime());
+        return Jwts.builder()
+            .setSubject(member.getEmail())
+            .claim(AUTHORITIES_KEY, member.getRole().toString())
+            .setExpiration(new Date(now + ACCESS_TOKEN_EXPIRE_TIME))
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
     }
 
     @Transactional(readOnly = true)
-    public RefreshToken isPresentRefreshToken(Member member) {
-        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMember(member);
-        return optionalRefreshToken.orElse(null);
+    public RefreshToken findRefreshTokenByKeyValue(String keyValue) {
+        return refreshTokenRepository.findByKeyValue(keyValue)
+            .orElseThrow(() -> new IllegalArgumentException("잘못된 리프레시 토큰 입니다."));
     }
 
 }

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/TokenProvider.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/TokenProvider.java
@@ -19,8 +19,8 @@ import java.util.Date;
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
-//    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30 * 2 * 24;            // 1일
+//    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final int ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30 * 2 * 24;            // 1일
     private static final int REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;     //7일
 
     private final Key key;

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/UserDetailsImpl.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/UserDetailsImpl.java
@@ -6,17 +6,15 @@ import com.lovely4k.backend.member.Role;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-@Component
 public class UserDetailsImpl implements UserDetails, MemberInfo {
 
     private Member member;
 
-    public UserDetailsImpl() {
+    private UserDetailsImpl() {
     }
 
     public UserDetailsImpl(Member member) {

--- a/api/src/main/java/com/lovely4k/backend/authentication/token/UserDetailsServiceImpl.java
+++ b/api/src/main/java/com/lovely4k/backend/authentication/token/UserDetailsServiceImpl.java
@@ -1,14 +1,11 @@
 package com.lovely4k.backend.authentication.token;
 
-import com.lovely4k.backend.member.Member;
 import com.lovely4k.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,8 +15,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Optional<Member> optionalUser = memberRepository.findByEmail(email);
-        return optionalUser
+        return memberRepository.findByEmail(email)
                 .map(UserDetailsImpl::new)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }

--- a/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarCommandService.java
+++ b/api/src/main/java/com/lovely4k/backend/calendar/service/CalendarCommandService.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.lovely4k.backend.common.ExceptionMessage.notFoundEntityMessage;
+import static com.lovely4k.backend.common.error.ExceptionMessage.notFoundEntityMessage;
 
 @Transactional
 @RequiredArgsConstructor

--- a/api/src/main/java/com/lovely4k/backend/common/error/ExceptionMessage.java
+++ b/api/src/main/java/com/lovely4k/backend/common/error/ExceptionMessage.java
@@ -1,4 +1,4 @@
-package com.lovely4k.backend.common;
+package com.lovely4k.backend.common.error;
 
 public final class ExceptionMessage {
 

--- a/api/src/main/java/com/lovely4k/backend/common/error/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/lovely4k/backend/common/error/GlobalExceptionHandler.java
@@ -1,7 +1,8 @@
-package com.lovely4k.backend.common;
+package com.lovely4k.backend.common.error;
 
 
 import com.amazonaws.AmazonClientException;
+import com.lovely4k.backend.common.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -9,9 +10,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.format.DateTimeParseException;
 
@@ -22,7 +25,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
         DateTimeParseException.class,
         EntityNotFoundException.class,
-        HttpMessageNotReadableException.class
+        HttpMessageNotReadableException.class,
+        AuthenticationCredentialsNotFoundException.class,
+        ResponseStatusException.class
     })
     public ResponseEntity<ApiResponse<ProblemDetail>> handleBadRequestExceptions(Exception e, HttpServletRequest request) {
         ProblemDetail problemDetail = ProblemDetailCreator.create(e, request, HttpStatus.BAD_REQUEST);

--- a/api/src/main/java/com/lovely4k/backend/common/error/OutsideDispatcherErrorHandler.java
+++ b/api/src/main/java/com/lovely4k/backend/common/error/OutsideDispatcherErrorHandler.java
@@ -1,0 +1,37 @@
+package com.lovely4k.backend.common.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+import static jakarta.servlet.RequestDispatcher.*;
+
+@RequiredArgsConstructor
+@RestController
+public class OutsideDispatcherErrorHandler implements ErrorController {
+
+    @GetMapping(value = "/error")
+    public ResponseEntity<String> handleError(HttpServletRequest request) {
+        int status = (int) request.getAttribute(ERROR_STATUS_CODE);
+        Throwable throwable = (Throwable) request.getAttribute(ERROR_EXCEPTION);
+        String exceptionMessage = throwable != null ? throwable.getMessage() : "null";
+
+        Map<String, Object> errorAttributes = Map.of(
+            "exceptionType", throwable != null ? throwable.getClass().getName() : "null",
+            "message", exceptionMessage,
+            "path", request.getAttribute(ERROR_REQUEST_URI),
+            "servletName", request.getAttribute(ERROR_SERVLET_NAME),
+            "statusCode", status,
+            "dispatchType", request.getDispatcherType().toString()
+        );
+
+        throw new ResponseStatusException(HttpStatusCode.valueOf(status), errorAttributes.toString());
+    }
+}

--- a/api/src/main/java/com/lovely4k/backend/common/error/ProblemDetailCreator.java
+++ b/api/src/main/java/com/lovely4k/backend/common/error/ProblemDetailCreator.java
@@ -1,4 +1,4 @@
-package com.lovely4k.backend.common;
+package com.lovely4k.backend.common.error;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;

--- a/api/src/main/java/com/lovely4k/backend/common/error/ValidationError.java
+++ b/api/src/main/java/com/lovely4k/backend/common/error/ValidationError.java
@@ -1,4 +1,4 @@
-package com.lovely4k.backend.common;
+package com.lovely4k.backend.common.error;
 
 import lombok.Builder;
 import org.springframework.validation.FieldError;

--- a/api/src/main/java/com/lovely4k/backend/common/log/Pointcuts.java
+++ b/api/src/main/java/com/lovely4k/backend/common/log/Pointcuts.java
@@ -7,7 +7,7 @@ public class Pointcuts {
     @Pointcut("execution(* com.lovely4k.backend..controller..*.*(..))")
     public void allController() { }
 
-    @Pointcut("within(com.lovely4k.backend.common.GlobalExceptionHandler)")
+    @Pointcut("within(com.lovely4k.backend.common.error.GlobalExceptionHandler)")
     public void globalExceptionHandler() { }
 
 }

--- a/api/src/main/java/com/lovely4k/backend/question/service/QuestionService.java
+++ b/api/src/main/java/com/lovely4k/backend/question/service/QuestionService.java
@@ -2,7 +2,6 @@ package com.lovely4k.backend.question.service;
 
 import com.lovely4k.backend.common.event.Events;
 import com.lovely4k.backend.couple.IncreaseTemperatureEvent;
-import com.lovely4k.backend.member.Sex;
 import com.lovely4k.backend.question.Question;
 import com.lovely4k.backend.question.QuestionForm;
 import com.lovely4k.backend.question.QuestionFormType;
@@ -22,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
-import static com.lovely4k.backend.common.ExceptionMessage.notFoundEntityMessage;
+import static com.lovely4k.backend.common.error.ExceptionMessage.notFoundEntityMessage;
 
 @Slf4j
 @Transactional(readOnly = true)

--- a/api/src/main/java/com/lovely4k/backend/question/service/QuestionServiceSupporter.java
+++ b/api/src/main/java/com/lovely4k/backend/question/service/QuestionServiceSupporter.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.lovely4k.backend.common.ExceptionMessage.notFoundEntityMessage;
+import static com.lovely4k.backend.common.error.ExceptionMessage.notFoundEntityMessage;
 
 /**
  * Question을 생성할 때 Couple 테이블을 통해 얻어와야 하는 정보, 검증해야 하는 로직들이 다수 있습니다. 이에 따라 별도의 클래스로 분리했고 db에서 값을 읽어와 couple 테이블의 필요한 데이터 정보를 반환하는 클래스라고 생각하면 될 것 같습니다. 초기에는 Couple 외에 다른 도메인의 정보가 필요할 수도 있다고 생각해서 Supporter라는 네이밍을 했는데 구현을 완료하니 Couple 테이블의 정보만 필요했습니다.

--- a/api/src/test/java/com/lovely4k/backend/ControllerTestSupport.java
+++ b/api/src/test/java/com/lovely4k/backend/ControllerTestSupport.java
@@ -1,11 +1,12 @@
 package com.lovely4k.backend;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.lovely4k.backend.authentication.*;
+import com.lovely4k.backend.authentication.CustomSuccessHandler;
+import com.lovely4k.backend.authentication.MyOAuth2Member;
+import com.lovely4k.backend.authentication.OAuth2UserService;
+import com.lovely4k.backend.authentication.OAuthAttributes;
 import com.lovely4k.backend.authentication.exception.AccessDeniedHandlerException;
 import com.lovely4k.backend.authentication.exception.AuthenticationEntryPointException;
-import com.lovely4k.backend.authentication.CustomSuccessHandler;
-import com.lovely4k.backend.authentication.token.SecurityConfig;
 import com.lovely4k.backend.authentication.token.TokenProvider;
 import com.lovely4k.backend.authentication.token.UserDetailsServiceImpl;
 import com.lovely4k.backend.calendar.controller.CalendarController;
@@ -28,12 +29,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -48,7 +55,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @ActiveProfiles("test")
-@Import(SecurityConfig.class)
+@Import(ControllerTestSupport.SecurityConfig.class)
 @WebMvcTest(controllers = {
     DiaryController.class,
     MemberController.class,
@@ -109,6 +116,34 @@ public abstract class ControllerTestSupport {
     @Mock
     protected Authentication authentication;
 
+    @MockBean
+    protected CalendarCommandService calendarCommandService;
+
+    @MockBean
+    protected CalendarQueryService calendarQueryService;
+
+    @TestConfiguration
+    static class SecurityConfig {
+
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+            http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+            ;
+
+            // Authorize of url
+            http
+                .authorizeHttpRequests(
+                    authorize -> authorize.anyRequest().permitAll()
+                );
+
+            return http.build();
+        }
+    }
+
     @BeforeEach
     void setUp() {
         when(securityContext.getAuthentication()).thenReturn(authentication);
@@ -121,7 +156,7 @@ public abstract class ControllerTestSupport {
         given(member.getNickname()).willReturn("깜찍이");
         given(member.getRole()).willReturn(Role.USER);
         given(member.getImageUrl()).willReturn("imageUrl");
-
+        given(authentication.getName()).willReturn(Role.USER.name());
         OAuthAttributes oAuthAttributes = new OAuthAttributes(
             Collections.emptyMap(),
             "test",
@@ -144,10 +179,4 @@ public abstract class ControllerTestSupport {
             .apply(springSecurity())
             .build();
     }
-
-    @MockBean
-    protected CalendarCommandService calendarCommandService;
-
-    @MockBean
-    protected CalendarQueryService calendarQueryService;
 }

--- a/api/src/test/java/com/lovely4k/backend/member/controller/MemberControllerTest.java
+++ b/api/src/test/java/com/lovely4k/backend/member/controller/MemberControllerTest.java
@@ -36,7 +36,6 @@ class MemberControllerTest extends ControllerTestSupport {
                     "white"
                 )
             );
-        System.out.println(memberService.findMemberProfile(memberId));
         //when //then
         mockMvc.perform(get("/v1/members"))
             .andDo(print())

--- a/api/src/test/java/com/lovely4k/backend/member/controller/MemberControllerTest.java
+++ b/api/src/test/java/com/lovely4k/backend/member/controller/MemberControllerTest.java
@@ -36,7 +36,7 @@ class MemberControllerTest extends ControllerTestSupport {
                     "white"
                 )
             );
-
+        System.out.println(memberService.findMemberProfile(memberId));
         //when //then
         mockMvc.perform(get("/v1/members"))
             .andDo(print())

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ sonar {
         property "sonar.projectKey", "Lovely-4K_love-backend"
         property "sonar.organization", "lovely-4k"
         property "sonar.host.url", "https://sonarcloud.io"
-        property 'sonar.coverage.exclusions', '**/*Request.java, **/*Response.java, **/docs, **/utils, **/*Config*.java, **/resources/**, **/*Exception*.java, **/com/lovely4k/backend/authentication/**, **/com/lovely4k/backend/common/sessionuser/**, **/*pointcut*.java'
+        property 'sonar.coverage.exclusions', '**/*Request.java, **/*Response.java, **/docs, **/utils, **/*Config*.java, **/resources/**, **/*Exception*.java, **/com/lovely4k/backend/authentication/**, **/com/lovely4k/backend/common/sessionuser/**, **/*pointcut*.java, **/com/lovely4k/backend/common/error/**'
         property 'sonar.exclusions', '**/*Application*.java'
     }
 }

--- a/model/src/main/java/com/lovely4k/backend/authentication/RefreshToken.java
+++ b/model/src/main/java/com/lovely4k/backend/authentication/RefreshToken.java
@@ -2,11 +2,9 @@ package com.lovely4k.backend.authentication;
 
 import com.lovely4k.backend.member.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -16,7 +14,7 @@ public class RefreshToken {
     private String id;
 
     @JoinColumn(name = "member_id", nullable = false)
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     private Member member;
 
     @Column(name = "key_value",nullable = false)

--- a/model/src/main/java/com/lovely4k/backend/authentication/RefreshTokenRepository.java
+++ b/model/src/main/java/com/lovely4k/backend/authentication/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByMember(Member member);
+
+    Optional<RefreshToken> findByKeyValue(String keyValue);
 }


### PR DESCRIPTION
## 🚀 Pull Request Template 🚀

### 📝 변경 이유 (Why did you make these changes?)

<!-- 여기에 변경 이유를 적어주세요-->

---

### ⚠️ 발견된 위험 또는 장애 (Identified Risks or Issues)

<!-- 발견된 위험이나 장애가 있다면 여기에 기록해주세요.-->

---

### 👀 리뷰 포커스 (Review Focus)

<!-- 리뷰어가 집중해야 할 부분을 알려주세요.-->
- 디스패처 서블릿 밖에서 처리되는 예외는 컨트롤러 어드바이스로 가지 않아 컨트롤러 어드바이스 내로 들어갈 수 있게 ErrorController를 커스텀해서 구현했습니다.
- 로그인 하지 않은 사용자가 SessionUser 객체를 사용하려고 할 때 로그인 예외를 터뜨렸습니다.
- access토큰을 발급하는 로직을 추가했습니다.
- JWT 필터 로직의 가독성이 떨어져 역할 별로 메소드를 나눴습니다.
  - 예외시 바디에 응답값 쓰기
  - 토큰으로 부터 claim 정보 얻어오기
  - SecurityContext에 Authentication 설정하기
 - 예외 관련 처리를 에러 패키지에 넣었습니다.
 - 유저의 role이 변경되더라도 test 코드에 영향이 없도록 설정했습니다.
 - UserDetails를 bean에 등록할 필요가 없어 component 어노테이션을 제거했씁니다.
 - 편의 상 필터 클래스를 빈에 등록했습니다.
---

### ✅ 테스트 계획 및 완료 사항 (Test Plans & Completed Items)

<!-- 테스트 계획과 완료한 사항을 여기에 적어주세요.-->

---

### :octocat: 기타 사항

<!-- 필요하다면 기타 전달하고 싶은 내용을 작성해주세요-->

🙏 리뷰해 주셔서 감사합니다! 🙏
