### PR TITLE
fix : 커플 프로필 조회 시 coupleStatus 변수 추가

### DIFF
--- a/api/src/docs/asciidoc/api/couple/couple-profile-get.adoc
+++ b/api/src/docs/asciidoc/api/couple/couple-profile-get.adoc
@@ -17,4 +17,13 @@ include::{snippets}/couple-profile-get/http-response.adoc[]
 
 다음은 커플 프로필 조회 시 응답 값에 대한 설명입니다.
 
+**coupleStatus**
+
+- SOLO : 커플이 맺어지기 전 상태
+- BREAKUP : 커플이 헤어진 상태
+- RELATIONSHIP : 커플인 상태
+- RECOUPLE : 커플이 재결합 신청한 상태
+
+
 include::{snippets}/couple-profile-get/response-fields.adoc[]
+

--- a/api/src/main/java/com/lovely4k/backend/couple/service/response/CoupleProfileGetResponse.java
+++ b/api/src/main/java/com/lovely4k/backend/couple/service/response/CoupleProfileGetResponse.java
@@ -1,6 +1,7 @@
 package com.lovely4k.backend.couple.service.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lovely4k.backend.couple.CoupleStatus;
 import com.lovely4k.backend.couple.repository.response.FindCoupleProfileResponse;
 
 import java.time.LocalDate;
@@ -20,7 +21,9 @@ public record CoupleProfileGetResponse(
     @JsonFormat(pattern = "yyyy-MM-dd") LocalDate opponentBirthday,
     String opponentCalendarColor,
 
-    @JsonFormat(pattern = "yyyy-MM-dd") LocalDate meetDay
+    @JsonFormat(pattern = "yyyy-MM-dd") LocalDate meetDay,
+
+    CoupleStatus coupleStatus
 ) {
     public static CoupleProfileGetResponse from(FindCoupleProfileResponse response) {
         return new CoupleProfileGetResponse(
@@ -36,7 +39,8 @@ public record CoupleProfileGetResponse(
             response.opponentId(),
             response.opponentBirthday(),
             response.opponentCalendarColor(),
-            response.meetDay()
+            response.meetDay(),
+            response.coupleStatus()
         );
     }
 }

--- a/api/src/test/java/com/lovely4k/backend/couple/controller/CoupleControllerTest.java
+++ b/api/src/test/java/com/lovely4k/backend/couple/controller/CoupleControllerTest.java
@@ -1,6 +1,7 @@
 package com.lovely4k.backend.couple.controller;
 
 import com.lovely4k.backend.ControllerTestSupport;
+import com.lovely4k.backend.couple.CoupleStatus;
 import com.lovely4k.backend.couple.controller.request.TestCoupleProfileEditRequest;
 import com.lovely4k.backend.couple.service.response.CoupleProfileGetResponse;
 import com.lovely4k.backend.couple.service.response.InvitationCodeCreateResponse;
@@ -76,7 +77,8 @@ class CoupleControllerTest extends ControllerTestSupport {
                 2L, // opponentId
                 LocalDate.of(1995, 10, 21),
                 "#C70039",
-                LocalDate.of(2020, 7, 23)
+                LocalDate.of(2020, 7, 23),
+                CoupleStatus.RELATIONSHIP
             )
         );
 

--- a/api/src/test/java/com/lovely4k/docs/couple/CoupleControllerDocsTest.java
+++ b/api/src/test/java/com/lovely4k/docs/couple/CoupleControllerDocsTest.java
@@ -1,6 +1,7 @@
 package com.lovely4k.docs.couple;
 
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.lovely4k.backend.couple.CoupleStatus;
 import com.lovely4k.backend.couple.controller.CoupleController;
 import com.lovely4k.backend.couple.controller.request.TestCoupleProfileEditRequest;
 import com.lovely4k.backend.couple.service.CoupleService;
@@ -25,7 +26,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -124,7 +124,8 @@ class CoupleControllerDocsTest extends RestDocsSupport {
                 2L, // opponentId
                 LocalDate.of(1995, 10, 21),
                 "#C70039",
-                LocalDate.of(2020, 7, 23)
+                LocalDate.of(2020, 7, 23),
+                CoupleStatus.RELATIONSHIP
             )
         );
 
@@ -151,7 +152,6 @@ class CoupleControllerDocsTest extends RestDocsSupport {
                             .description("나의 달력 색깔"),
                         fieldWithPath("body.myBirthday").type(JsonFieldType.STRING)
                             .description("나의 생일"),
-
                         fieldWithPath("body.opponentNickname").type(JsonFieldType.STRING)
                             .description("상대방 별명"),
                         fieldWithPath("body.opponentMbti").type(JsonFieldType.STRING)
@@ -166,6 +166,8 @@ class CoupleControllerDocsTest extends RestDocsSupport {
                             .description("상대방 달력 색깔"),
                         fieldWithPath("body.opponentBirthday").type(JsonFieldType.STRING)
                             .description("상대방 생일"),
+                        fieldWithPath("body.coupleStatus").type(JsonFieldType.STRING)
+                            .description("커플 상태"),
                         fieldWithPath("links[0].rel").type(JsonFieldType.STRING)
                             .description("relation of url"),
                         fieldWithPath("links[0].href").type(JsonFieldType.STRING)

--- a/model/src/main/java/com/lovely4k/backend/couple/Couple.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/Couple.java
@@ -84,7 +84,7 @@ public class Couple extends BaseTimeEntity {
             .meetDay(null)
             .invitationCode(invitationCode)
             .temperature(0.0f)
-            .coupleStatus(CoupleStatus.RELATIONSHIP)
+            .coupleStatus(CoupleStatus.SOLO)
             .build();
     }
 
@@ -95,16 +95,8 @@ public class Couple extends BaseTimeEntity {
             .meetDay(null)
             .invitationCode(invitationCode)
             .temperature(0.0f)
-            .coupleStatus(CoupleStatus.RELATIONSHIP)
+            .coupleStatus(CoupleStatus.SOLO)
             .build();
-    }
-
-    public void registerGirlId(Long receivedMemberId) {
-        this.girlId = receivedMemberId;
-    }
-
-    public void registerBoyId(Long receivedMemberId) {
-        this.boyId = receivedMemberId;
     }
 
     public void update(LocalDate meetDay) {
@@ -134,6 +126,7 @@ public class Couple extends BaseTimeEntity {
         } else {
             this.girlId = receivedMemberId;
         }
+        this.coupleStatus = CoupleStatus.RELATIONSHIP;
     }
   
     public boolean isExpired(LocalDate requestedDate) {

--- a/model/src/main/java/com/lovely4k/backend/couple/CoupleStatus.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/CoupleStatus.java
@@ -1,5 +1,5 @@
 package com.lovely4k.backend.couple;
 
 public enum CoupleStatus {
-    BREAKUP, RELATIONSHIP, RECOUPLE
+    BREAKUP, RELATIONSHIP, RECOUPLE, SOLO
 }

--- a/model/src/main/java/com/lovely4k/backend/couple/repository/CoupleQueryRepository.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/repository/CoupleQueryRepository.java
@@ -35,7 +35,8 @@ public class CoupleQueryRepository {
                 opponent.id,
                 opponent.birthday,
                 opponent.calendarColor,
-                couple.meetDay
+                couple.meetDay,
+                couple.coupleStatus
             ))
             .from(my)
             .leftJoin(couple).on(my.coupleId.eq(couple.id))

--- a/model/src/main/java/com/lovely4k/backend/couple/repository/response/FindCoupleProfileResponse.java
+++ b/model/src/main/java/com/lovely4k/backend/couple/repository/response/FindCoupleProfileResponse.java
@@ -1,5 +1,7 @@
 package com.lovely4k.backend.couple.repository.response;
 
+import com.lovely4k.backend.couple.CoupleStatus;
+
 import java.time.LocalDate;
 
 public record FindCoupleProfileResponse(
@@ -15,6 +17,7 @@ public record FindCoupleProfileResponse(
     Long opponentId,
     LocalDate opponentBirthday,
     String opponentCalendarColor,
-    LocalDate meetDay
+    LocalDate meetDay,
+    CoupleStatus coupleStatus
 ) {
 }


### PR DESCRIPTION
## 🚀 Pull Request Template 🚀

### 📝 변경 이유 (Why did you make these changes?)

<!-- 여기에 변경 이유를 적어주세요-->
- Front측에서 커플 조회 시 커플의 상태를 알 수 있는 변수를 요청하였습니다.
---

### ⚠️ 발견된 위험 또는 장애 (Identified Risks or Issues)

<!-- 발견된 위험이나 장애가 있다면 여기에 기록해주세요.-->
- 없습니다.
---

### 👀 리뷰 포커스 (Review Focus)

<!-- 리뷰어가 집중해야 할 부분을 알려주세요.-->
- 변경 부분이 적어 집중해야할 부분은 없고, 전반적으로 검토 부탁드립니다!
- docs에 커플 상태에 따른 설명을 작성하였는데 이 부분 올바른지 확인 부탁드립니다.
---

### ✅ 테스트 계획 및 완료 사항 (Test Plans & Completed Items)

<!-- 테스트 계획과 완료한 사항을 여기에 적어주세요.-->
- 테스트 완료하였습니다.
---

### :octocat: 기타 사항

<!-- 필요하다면 기타 전달하고 싶은 내용을 작성해주세요-->

🙏 리뷰해 주셔서 감사합니다! 🙏
